### PR TITLE
DIRECTORY-5796: add endpoints for group_types and groups

### DIFF
--- a/lib/namely/connection.rb
+++ b/lib/namely/connection.rb
@@ -78,6 +78,20 @@ module Namely
       collection("reports")
     end
 
+    # Return a Collection of group types.
+    #
+    # @return [Collection]
+    def group_types
+      collection("group_types")
+    end
+
+    # Return a Collection of groups.
+    #
+    # @return [Collection]
+    def groups
+      collection("groups")
+    end
+
     private
 
     attr_reader :access_token, :subdomain


### PR DESCRIPTION
## Status
READY

## Migrations
NO

## Description
this is the first half change to add endpoints for group_types and groups to Namely gem itself (namely-ruby-client)
the other half of the change is to use the newly published gem for Namely directory to support individual group for schema and user sync, it's in directory-service https://github.com/onelogin/directory-service/pull/296


## Related PRs

branch | PR
------ | ------
namely-ruby-client | [link](https://github.com/onelogin/namely-ruby-client/commit/107de6f74874b6bde7e1effcda070359fd5d2e6a)
directory-service | [link](https://github.com/onelogin/directory-service/pull/296)

#### Jira
* https://onelogin2.atlassian.net/browse/DIRECTORY-5796

